### PR TITLE
TCA not initialized

### DIFF
--- a/class.tx_pagepath_resolver.php
+++ b/class.tx_pagepath_resolver.php
@@ -52,6 +52,10 @@ class tx_pagepath_resolver {
 			$this->parameters = $params['parameters'];
 		}
 
+		if (method_exists('tslib_eidtools', 'initTCA')) {
+			tslib_eidtools::initTCA();
+		}
+
 		tslib_eidtools::connectDB();
 	}
 


### PR DESCRIPTION
This changeset fixes a php exception that was thrown
because the pages_language_overlay tca configuration was
missing by initializing the whole TCA.
